### PR TITLE
Handle unavailable battery channel in board info

### DIFF
--- a/brainflow_labram_integration.py
+++ b/brainflow_labram_integration.py
@@ -335,10 +335,12 @@ class BrainFlowLaBraMPipeline:
             battery_channel = BoardShim.get_battery_channel(BoardIds.CYTON_BOARD.value)
             battery_level = None
             
-            if battery_channel is not None:
+            if battery_channel is not None and battery_channel >= 0:
                 data = self.board.get_board_data(1)
                 if data.shape[0] > battery_channel:
                     battery_level = float(data[battery_channel, -1])
+            else:
+                battery_level = None
             
             return {
                 "board_id": BoardIds.CYTON_BOARD.value,


### PR DESCRIPTION
## Summary
- Guard battery-level retrieval by validating the battery channel index
- Return `None` when the battery channel is not available

## Testing
- `python -m py_compile brainflow_labram_integration.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd8993bd30832d90af540aa1766923