### PR TITLE
Use sampling rate to pause for impedance samples

### DIFF
--- a/electrode_detection.py
+++ b/electrode_detection.py
@@ -80,7 +80,8 @@ class ElectrodeDetector:
         """
         if channel < 1 or channel > 8:
             raise ValueError("Channel must be between 1 and 8")
-        
+        wait = samples / CYTON_SAMPLING_RATE
+
         try:
             # Stop any existing stream
             try:
@@ -95,11 +96,11 @@ class ElectrodeDetector:
             
             # Wait for command to take effect
             time.sleep(0.1)
-            
+
             # Start streaming and collect data
             self.board.start_stream()
-            time.sleep(0.1)  # Allow stream to stabilize
-            
+            time.sleep(wait)  # Allow enough samples to be collected
+
             # Collect samples
             data = self.board.get_board_data(samples)
             self.board.stop_stream()


### PR DESCRIPTION
## Summary
- compute wait time based on sampling rate in `measure_impedance`
- wait for collected sample duration instead of fixed pause when starting stream

## Testing
- `python -m py_compile electrode_detection.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd8989e26c832d8ce989753b037763